### PR TITLE
CI-nitropc - Add ISO_NAME & Use GitLab  Container Registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ oem-build:
   script:
     - make ci
     - mkdir -p artifacts
-    - cp *nitrokey*.iso artifacts/
+    - cp *nitropc*.iso artifacts/
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:

--- a/ISO_NAME
+++ b/ISO_NAME
@@ -1,0 +1,1 @@
+debian-10.8-nitropc-oem-amd64.iso

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 myperms=$(shell id -u).$(shell id -g)
+iso_name=`cat ./ISO_NAME`
 
 all: clean image
 	-docker stop deb
@@ -12,8 +13,8 @@ ci: image
 
 build:
 	build-simple-cdd --conf nk.conf --force-root --force-preseed
-	cp images/debian-10-amd64-CD-1.iso nitrokey-debian-oem.iso
-	@echo "image: ./nitrokey-debian-oem.iso"
+	cp images/debian-10-amd64-CD-1.iso $(iso_name)
+	@echo "image: $(iso_name)"
 
 image:
 	docker build -t nk/debian-image .


### PR DESCRIPTION
Set .iso name in ISO_NAME file.

All Test passed: https://git.dotplex.com/nitrokey/debian-oem/-/pipelines/15119
Upload: https://www.nitrokey.com/files/ci/nitropc/debian-oem/