### PR TITLE
CI-nitropc - Add ISO_NAME & Use GitLab Container Registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ include: 'https://raw.githubusercontent.com/Nitrokey/common-ci-jobs/master/commo
 
 stages:
   - pull-github
+  - build 
   - deploy
 
 variables:
@@ -12,25 +13,26 @@ variables:
   REPO_USER: nitrokey
   REPO_NAME: debian-oem
   MAIN_BRANCH: nitropad
+  COMMON_PULL: "true"
+  COMMON_UPLOAD_NIGHTLY: "false"
+  COMMON_GITHUB_RELEASE: "false"
+  COMMON_UPLOAD_FILES: "true"
+  DEVICE_FOLDER: "nitropad"
+  UPLOAD_FOLDER: "debian-oem"
 
-oem-release:
+oem-build:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
   tags:
     - lxc
-  stage: deploy
-  before_script:
-    - echo "-----BEGIN OPENSSH PRIVATE KEY-----" > ~/.ssh/common_scripts_key
-    - echo "$COMMON_SCRIPTS_KEY" >> ~/.ssh/common_scripts_key
-    - echo "-----END OPENSSH PRIVATE KEY-----" >> ~/.ssh/common_scripts_key
-    - chmod 600 ~/.ssh/common_scripts_key
-    - export SCRIPTS_DIR=$(mktemp -d)
-    - git clone -q --depth 1 $SCRIPTS_REPO $SCRIPTS_DIR
+  stage: build
   script:
     - make ci
-    - chmod +x $SCRIPTS_DIR/ci-scripts/oem-release.sh
-    - $SCRIPTS_DIR/ci-scripts/oem-release.sh *nitrokey*.iso
+    - mkdir -p artifacts
+    - cp *nitropad*.iso artifacts/
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
-
-
+  artifacts:
+    paths:
+      - artifacts
+    expire_in: 1 hrs

--- a/ISO_NAME
+++ b/ISO_NAME
@@ -1,0 +1,1 @@
+debian-10.8-nitropad-oem-amd64.iso

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 myperms=$(shell id -u).$(shell id -g)
+iso_name=`cat ./ISO_NAME`
 
 all: clean clean
 	-docker stop deb
@@ -12,8 +13,8 @@ ci: image
 
 build:
 	build-simple-cdd --conf nk.conf --force-root --force-preseed
-	cp images/debian-10-amd64-CD-1.iso nitrokey-debian-oem.iso
-	@echo "image: ./nitrokey-debian-oem.iso"
+	cp images/debian-10-amd64-CD-1.iso $(iso_name)
+	@echo "image: $(iso_name)"
 
 image:
 	docker build -t nk/debian-image .


### PR DESCRIPTION
Set .iso name in ISO_NAME file.

All Test passed: https://git.dotplex.com/nitrokey/debian-oem/-/pipelines/15121
Upload: https://www.nitrokey.com/files/ci/nitropad/debian-oem/